### PR TITLE
Update build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/notifications-center",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Notification center maintained by Dynamo Team@Autodesk",
   "author": "Autodesk Inc.",
   "license": "MIT",

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
 <body>
     <div id="root"></div>
     <script src="index.bundle.js"></script>
+    <script>mainJs</script>
 </body>
 
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,5 +40,5 @@ module.exports = {
             }),
         ],
     },
-    mode: 'development'
+    mode: 'production'
 }


### PR DESCRIPTION
- Change the default webpack bundle option to `production` so we can shrink size of the package to be under 2mb, otherwise getting into the error of https://github.com/MicrosoftEdge/WebView2Feedback/issues/2281. Thanks @filipeotero ! This get our package to about 600kb so Dynamo can consume without problem
- Add a script tag specifically for Dynamo to inject javascript at https://github.com/DynamoDS/Dynamo/blob/master/src/Notifications/NotificationCenterController.cs#L66. But I'm removing the # symbol because that will cause an error.

FYI: @DynamoDS/dynamo 