### PR TITLE
Use dev mode by default for Windows Machine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynamods/notifications-center",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynamods/notifications-center",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/notifications-center",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Notification center maintained by Dynamo Team@Autodesk",
   "author": "Autodesk Inc.",
   "license": "MIT",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
-    mode: 'none',
+    mode: 'development',
     entry: {
         app: './src/index.js',
     },


### PR DESCRIPTION
According to @reddyashish It seems the default mode for Webpack configure does not impact Mac but I find difficulty using `none` mode on Windows machines, so setting default back to development. We still need to check if the npm script WebPack Cli command param will overwrite this mode correctly when v0.0.9 published