### PR TITLE
DYN-5235-NotificationsCenter-Localization Part1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/notifications-center",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Notification center maintained by Dynamo Team@Autodesk",
   "author": "Autodesk Inc.",
   "license": "MIT",

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import Timestamp from '@hig/timestamp';
 import axios from 'axios';
 
 function App() {
-  const [APIData, setAPIData] = useState({ loaded: false, notifications: [], title: "Notifications", bottomButtonText: "Mark all as read" });
+  const [APIData, setAPIData] = useState({ loaded: false, notifications: [], title: 'Notifications', bottomButtonText: 'Mark all as read' });
   useEffect(() => {
     if (process.env.NOTIFICATION_URL) {
       axios.get(process.env.NOTIFICATION_URL)

--- a/src/App.js
+++ b/src/App.js
@@ -82,7 +82,6 @@ function App() {
 
   const setTitle = (titleText) => {
     setAPIData( prevState => {
-      console.log( prevState.notificabottomButtonText);
       return {       
         loaded: prevState.loaded,
         notifications: prevState.notifications,

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import Timestamp from '@hig/timestamp';
 import axios from 'axios';
 
 function App() {
-  const [APIData, setAPIData] = useState({ loaded: false, notifications: [] });
+  const [APIData, setAPIData] = useState({ loaded: false, notifications: [], title: "Notifications", bottomButtonText: "Mark all as read" });
   useEffect(() => {
     if (process.env.NOTIFICATION_URL) {
       axios.get(process.env.NOTIFICATION_URL)
@@ -20,6 +20,8 @@ function App() {
         });
     } else {
       window.setNotifications = setNotifications;
+      window.setTitle = setTitle;
+      window.setBottomButtonText = setBottomButtonText;
     }
   }, []);
 
@@ -28,7 +30,9 @@ function App() {
     setAPIData(prevState => {
       return {
         loaded: true,
-        notifications: [...prevState.notifications, ...notificationsData]
+        notifications: [...prevState.notifications, ...notificationsData],
+        title: prevState.title,
+        bottomButtonText: prevState.bottomButtonText
       };
     });
   };
@@ -64,7 +68,9 @@ function App() {
     setAPIData(() => {
       return {
         loaded: true,
-        notifications: notificationsData
+        notifications: notificationsData,
+        title: APIData.title,
+        bottomButtonText: APIData.bottomButtonText
       };
     });
 
@@ -74,9 +80,33 @@ function App() {
     }
   };
 
+  const setTitle = (titleText) => {
+    setAPIData( prevState => {
+      console.log( prevState.notificabottomButtonText);
+      return {       
+        loaded: prevState.loaded,
+        notifications: prevState.notifications,
+        title: titleText,
+        bottomButtonText: prevState.bottomButtonText,
+      };             
+    });
+  };
+
+  const setBottomButtonText = (buttonText) => {
+    setAPIData( prevState => {
+      return {
+        loaded: prevState.loaded,
+        notifications: prevState.notifications,
+        title: prevState.title,
+        bottomButtonText: buttonText,
+      };             
+    });
+  };
+
   return APIData.loaded ?
     <NotificationsPanel class="NotificationsFlyout"
-      heading="Notifications"
+      heading={APIData.title}
+      markAllAsReadTitle={APIData.bottomButtonText}
       indicatorTitle="View application alerts"
       onClickMarkAllAsRead={markAllAsRead}
       notifications={APIData.notifications}>


### PR DESCRIPTION
### Purpose
Localization of NotificationsCenter part1.
I've added two js methods, one will change the NotificationsCenter title window (by default is "Notifications"), the second one will change the bottom button text (current the default is "Mark all as read"). After this changes once they are published in npm.org this methods can be called from Dynamo so we can localize this content.

### Declarations

Check these if you believe they are true

- [X] The codebase is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- [X] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Release Notes

Localization of NotificationsCenter part1.


### Reviewers

@QilongTang 

### FYIs

