### PR TITLE
DYN-5194 add http protocol to notification link in case it is missing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -31,15 +31,7 @@ function App() {
     }
   },[]);
 
-  const validateNotificationUrl = (url) => {
-    let parseURL = url;
-
-    if (!url.includes("//")){
-      parseURL = "http://" + url;
-    }
-    
-    return parseURL;
-  };
+  const validateNotificationUrl = (url) => !url.startsWith("https://") ? `https://${url}` : url;
 
   const setPopupHeight = () => {
     if(chrome.webview === undefined) return;

--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,16 @@ function App() {
     }
   },[]);
 
+  const validateNotificationUrl = (url) => {
+    let parseURL = url;
+
+    if (!url.includes("//")){
+      parseURL = "http://" + url;
+    }
+    
+    return parseURL;
+  };
+
   const setPopupHeight = () => {
     if(chrome.webview === undefined) return;
     chrome.webview.hostObjects.scriptObject.UpdateNotificationWindowSize(document.body.scrollHeight);
@@ -70,7 +80,7 @@ function App() {
         content: <div>
           <b>{notifications[i].title}</b>
           <p>{notifications[i].longDescription}</p>
-          <a href={notifications[i].link} target="_blank" rel="noreferrer">{notifications[i].linkTitle}</a>
+          <a href={validateNotificationUrl(notifications[i].link)} target="_blank" rel="noreferrer">{notifications[i].linkTitle}</a>
         </div>
       };
       notificationsData.push(notificationItem);


### PR DESCRIPTION
Ref.: [[DYN-5194]](https://jira.autodesk.com/browse/DYN-5194)

This PR is for getting rid of app chooser when clicking the notification link. We included a url validation adding the protocol in case it's missing.

**Review**
@QilongTang 
@avidit 