### PR TITLE
Update dependencies for GL 4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         env:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
         with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,10 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci --force
       - run: npm run build:dev --if-present
       - run: npm test
@@ -27,10 +27,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: npm ci --force
       - run: npm run production --if-present

--- a/license_output/about-box_direct.html
+++ b/license_output/about-box_direct.html
@@ -7,30 +7,24 @@
   <div>
     <p>
       <strong>
-    All use of this Software is subject to the terms and conditions of the Autodesk license agreement accepted upon 
-    installation of this Software and/or packaged with the Software. Autodesk software license agreements for Autodesk&rsquo;s various 
-    products 
-    can be found
-      <a href="https://www.autodesk.com/company/terms-of-use/en/general-terms"> here</a>
-      .
+      This Offering is subject to the Autodesk Terms of Use found
+      <a href="https://www.autodesk.com/company/terms-of-use/en/general-terms">here</a>,
+      which you accepted during your Autodesk account registration or subscription process, or by
+      installing, 
+      accessing or using this Offering.
     </strong>
-      <br />
-      <br />
     </p>
     <p>
       <strong>Privacy</strong>
-    </p>
-    <p>
+      <br />
       To learn more about Autodesk&rsquo;s online and offline privacy practices, please see the
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/privacy-statement"> Autodesk Privacy Statement</a>
-      .
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/privacy-statement">Autodesk Privacy Statement</a>.
     </p>
     <p>
       <strong>Autodesk Trademarks</strong>
-    </p>
-    <p>
+      <br />
       The trademarks on the
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks"> Autodesk Trademarks page</a>
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks">Autodesk Trademarks page</a>
       are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries.
     </p>
     <p>
@@ -38,33 +32,32 @@
     </p>
     <p>
       <strong>Patents</strong>
-    </p>
-    <p>
+      <br />
       This
       Product or Service
       is protected by patents listed on the
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/patents"> Autodesk Patents</a>
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/patents">Autodesk Patents</a>
       page.
     </p>
     <p>
       <strong>Autodesk Cloud and Desktop Components</strong>
-    </p>
-    <p>
-      This Product or Service may incorporate or use background Autodesk online and desktop technology components. For information about these components, see
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-components"> Autodesk Cloud Platform Components</a>
-      and
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components"> Autodesk Desktop Platform Components</a>
-      .
+      <br />
+      This
+      Product or Service
+      may incorporate or use background Autodesk online and desktop technology components. For information about these components, see
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components">Autodesk Internal Components</a>.
     </p>
     <p>
       <strong>
       Third-Party Trademarks, Software Credits and Attributions
     </strong>
     </p>
-    <span data-name="@dynamods/notifications-center" data-license="MIT">
-      <strong>@dynamods/notifications-center</strong>: Copyright (c) 2024 DynamoDS
-      <br />
-      <span>
+    <span data-name="&#64;dynamods/notifications-center" data-license="MIT">
+        <strong>&#64;dynamods/notifications-center</strong>:
+        <br />
+        Copyright (c) 2025 DynamoDS
+        <br />
+        <span>
         Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       </span>
     <p>
@@ -75,9 +68,11 @@
     </p>
     </span>
     <span data-name="react-dom" data-license="MIT">
-      <strong>react-dom</strong>: Copyright (c) Facebook, Inc. and its affiliates.
-      <br />
-      <span>
+        <strong>react-dom</strong>:
+        <br />
+        Copyright (c) Facebook, Inc. and its affiliates.
+        <br />
+        <span>
         Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       </span>
     <p>
@@ -88,9 +83,11 @@
     </p>
     </span>
     <span data-name="react" data-license="MIT">
-      <strong>react</strong>: Copyright (c) Facebook, Inc. and its affiliates.
-      <br />
-      <span>
+        <strong>react</strong>:
+        <br />
+        Copyright (c) Facebook, Inc. and its affiliates.
+        <br />
+        <span>
         Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       </span>
     <p>

--- a/license_output/about-box_transitive.html
+++ b/license_output/about-box_transitive.html
@@ -7,30 +7,24 @@
   <div>
     <p>
       <strong>
-    All use of this Software is subject to the terms and conditions of the Autodesk license agreement accepted upon 
-    installation of this Software and/or packaged with the Software. Autodesk software license agreements for Autodesk&rsquo;s various 
-    products 
-    can be found
-      <a href="https://www.autodesk.com/company/terms-of-use/en/general-terms"> here</a>
-      .
+      This Offering is subject to the Autodesk Terms of Use found
+      <a href="https://www.autodesk.com/company/terms-of-use/en/general-terms">here</a>,
+      which you accepted during your Autodesk account registration or subscription process, or by
+      installing, 
+      accessing or using this Offering.
     </strong>
-      <br />
-      <br />
     </p>
     <p>
       <strong>Privacy</strong>
-    </p>
-    <p>
+      <br />
       To learn more about Autodesk&rsquo;s online and offline privacy practices, please see the
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/privacy-statement"> Autodesk Privacy Statement</a>
-      .
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/privacy-statement">Autodesk Privacy Statement</a>.
     </p>
     <p>
       <strong>Autodesk Trademarks</strong>
-    </p>
-    <p>
+      <br />
       The trademarks on the
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks"> Autodesk Trademarks page</a>
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/intellectual-property/trademarks">Autodesk Trademarks page</a>
       are registered trademarks or trademarks of Autodesk, Inc., and/or its subsidiaries and/or affiliates in the USA and/or other countries.
     </p>
     <p>
@@ -38,33 +32,32 @@
     </p>
     <p>
       <strong>Patents</strong>
-    </p>
-    <p>
+      <br />
       This
       Product or Service
       is protected by patents listed on the
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/patents"> Autodesk Patents</a>
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/patents">Autodesk Patents</a>
       page.
     </p>
     <p>
       <strong>Autodesk Cloud and Desktop Components</strong>
-    </p>
-    <p>
-      This Product or Service may incorporate or use background Autodesk online and desktop technology components. For information about these components, see
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-cloud-platform-components"> Autodesk Cloud Platform Components</a>
-      and
-      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components"> Autodesk Desktop Platform Components</a>
-      .
+      <br />
+      This
+      Product or Service
+      may incorporate or use background Autodesk online and desktop technology components. For information about these components, see
+      <a href="https://www.autodesk.com/company/legal-notices-trademarks/autodesk-desktop-platform-components">Autodesk Internal Components</a>.
     </p>
     <p>
       <strong>
       Third-Party Trademarks, Software Credits and Attributions
     </strong>
     </p>
-    <span data-name="@dynamods/notifications-center" data-license="MIT">
-      <strong>@dynamods/notifications-center</strong>: Copyright (c) 2024 DynamoDS
-      <br />
-      <span>
+    <span data-name="&#64;dynamods/notifications-center" data-license="MIT">
+        <strong>&#64;dynamods/notifications-center</strong>:
+        <br />
+        Copyright (c) 2025 DynamoDS
+        <br />
+        <span>
         Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       </span>
     <p>
@@ -75,9 +68,11 @@
     </p>
     </span>
     <span data-name="js-tokens" data-license="MIT">
-      <strong>js-tokens</strong>: Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell
-      <br />
-      <span>
+        <strong>js-tokens</strong>:
+        <br />
+        Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell
+        <br />
+        <span>
         Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       </span>
     <p>
@@ -88,9 +83,11 @@
     </p>
     </span>
     <span data-name="loose-envify" data-license="MIT">
-      <strong>loose-envify</strong>: Copyright (c) 2015 Andres Suarez &lt;zertosh@gmail.com&gt;
-      <br />
-      <span>
+        <strong>loose-envify</strong>:
+        <br />
+        Copyright (c) 2015 Andres Suarez &lt;zertosh&#64;gmail.com&gt;
+        <br />
+        <span>
         Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       </span>
     <p>
@@ -101,9 +98,11 @@
     </p>
     </span>
     <span data-name="react-dom" data-license="MIT">
-      <strong>react-dom</strong>: Copyright (c) Facebook, Inc. and its affiliates.
-      <br />
-      <span>
+        <strong>react-dom</strong>:
+        <br />
+        Copyright (c) Facebook, Inc. and its affiliates.
+        <br />
+        <span>
         Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       </span>
     <p>
@@ -114,9 +113,11 @@
     </p>
     </span>
     <span data-name="react" data-license="MIT">
-      <strong>react</strong>: Copyright (c) Facebook, Inc. and its affiliates.
-      <br />
-      <span>
+        <strong>react</strong>:
+        <br />
+        Copyright (c) Facebook, Inc. and its affiliates.
+        <br />
+        <span>
         Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       </span>
     <p>
@@ -127,9 +128,11 @@
     </p>
     </span>
     <span data-name="scheduler" data-license="MIT">
-      <strong>scheduler</strong>: Copyright (c) Facebook, Inc. and its affiliates.
-      <br />
-      <span>
+        <strong>scheduler</strong>:
+        <br />
+        Copyright (c) Facebook, Inc. and its affiliates.
+        <br />
+        <span>
         Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
       </span>
     <p>

--- a/license_output/paos_direct.csv
+++ b/license_output/paos_direct.csv
@@ -1,4 +1,4 @@
 publisher,name,version,copyright,dateAdded,estimatedReleaseDate,license,distributed
-"Autodesk Inc.",@dynamods/notifications-center,"0.0.32","Copyright (c) 2025 DynamoDS","","",MIT,false
+"Autodesk Inc.",@dynamods/notifications-center,"0.0.33","Copyright (c) 2025 DynamoDS","","",MIT,false
 "",react-dom,"18.2.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false
 "",react,"18.2.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false

--- a/license_output/paos_direct.csv
+++ b/license_output/paos_direct.csv
@@ -1,4 +1,4 @@
 publisher,name,version,copyright,dateAdded,estimatedReleaseDate,license,distributed
-"Autodesk Inc.",@dynamods/notifications-center,"0.0.31","Copyright (c) 2025 DynamoDS","","",MIT,false
+"Autodesk Inc.",@dynamods/notifications-center,"0.0.32","Copyright (c) 2025 DynamoDS","","",MIT,false
 "",react-dom,"18.2.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false
 "",react,"18.2.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false

--- a/license_output/paos_transitive.csv
+++ b/license_output/paos_transitive.csv
@@ -1,5 +1,5 @@
 publisher,name,version,copyright,dateAdded,estimatedReleaseDate,license,distributed
-"Autodesk Inc.",@dynamods/notifications-center,"0.0.32","Copyright (c) 2025 DynamoDS","","",MIT,false
+"Autodesk Inc.",@dynamods/notifications-center,"0.0.33","Copyright (c) 2025 DynamoDS","","",MIT,false
 "Simon Lydell",js-tokens,"4.0.0","Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell","","",MIT,false
 "Andres Suarez",loose-envify,"1.4.0","Copyright (c) 2015 Andres Suarez <zertosh@gmail.com>","","",MIT,false
 "",react-dom,"18.2.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false

--- a/license_output/paos_transitive.csv
+++ b/license_output/paos_transitive.csv
@@ -1,5 +1,5 @@
 publisher,name,version,copyright,dateAdded,estimatedReleaseDate,license,distributed
-"Autodesk Inc.",@dynamods/notifications-center,"0.0.31","Copyright (c) 2025 DynamoDS","","",MIT,false
+"Autodesk Inc.",@dynamods/notifications-center,"0.0.32","Copyright (c) 2025 DynamoDS","","",MIT,false
 "Simon Lydell",js-tokens,"4.0.0","Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell","","",MIT,false
 "Andres Suarez",loose-envify,"1.4.0","Copyright (c) 2015 Andres Suarez <zertosh@gmail.com>","","",MIT,false
 "",react-dom,"18.2.0","Copyright (c) Facebook, Inc. and its affiliates.","","",MIT,false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dynamods/notifications-center",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dynamods/notifications-center",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "license": "MIT",
       "dependencies": {
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dynamods/notifications-center",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Notification center maintained by Dynamo Team@Autodesk",
   "author": "Autodesk Inc.",
   "license": "MIT",


### PR DESCRIPTION
It seems the application is still using HIG which was deprecated/moved over to Weave, therefore some parts of the project still point to react 16, this will need more work to upgrade, will file a separate task for that. Maybe we can now use weave instead of our own fork of HIG.

For now just updating the dependencies and license